### PR TITLE
Define node_modules as named volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,14 @@
-chat:
-  build: .
-  command: node_modules/.bin/nodemon index.js
-  environment:
-    NODE_ENV: development
-  ports:
-    - '3000:3000'
-  volumes:
-    - .:/home/app/chat
-    - /home/app/chat/node_modules
+version: '2'
+volumes:
+  nodemodules:
+services:
+  chat:
+    build: .
+    command: node_modules/.bin/nodemon index.js
+    environment:
+      NODE_ENV: development
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/home/app/chat
+      - nodemodules:/home/app/chat/node_modules


### PR DESCRIPTION
Solves the “_[because we ran that container as a one-off docker-compose run, the actual modules we installed have vanished](http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html#package-installation-and-shrinkwrap)_” issue mentioned in the “[Lessons from Building a Node App in Docker](http://jdlm.info/articles/2016/03/06/lessons-building-node-app-docker.html)” blog post.

Define node_modules directory as named volume so it will be automatically attached in one-off `docker-compose run` containers allowing `npm install` to have an effect without the need to rebuild containers:

![image](https://cloud.githubusercontent.com/assets/679146/18364899/ed19ed30-7618-11e6-9642-08bf85ab6bb5.png)

**This requires compose file version 2 syntax**: https://docs.docker.com/compose/compose-file/#/version-2 (which I think requires Docker Engine 1.10.0 or newer)

For persisting with named modules, see:
- https://github.com/brikis98/docker-osx-dev/issues/168#issuecomment-218497871
- https://github.com/docker/docker/issues/17798
